### PR TITLE
UriToDocumentTextAnnotator - Closing stream after reading

### DIFF
--- a/cleartk-util/src/main/java/org/cleartk/util/ae/UriToDocumentTextAnnotator.java
+++ b/cleartk-util/src/main/java/org/cleartk/util/ae/UriToDocumentTextAnnotator.java
@@ -79,8 +79,8 @@ public class UriToDocumentTextAnnotator extends JCasAnnotator_ImplBase {
     URI uri = ViewUriUtil.getURI(jCas);
     String content;
 
-    try {
-      content = CharStreams.toString(new InputStreamReader(uri.toURL().openStream()));
+    try (InputStreamReader reader = new InputStreamReader(uri.toURL().openStream())) {
+      content = CharStreams.toString(reader);
       jCas.setSofaDataString(content, "text/plain");
     } catch (MalformedURLException e) {
       throw new AnalysisEngineProcessException(e);


### PR DESCRIPTION
UriToDocumentTextAnnotator does not close the stream after reading which results in open file handlers in the system. Adding logic to do the close.