### PR TITLE
added featurename from named sub-extractor

### DIFF
--- a/cleartk-ml/src/main/java/org/cleartk/ml/feature/extractor/CleartkExtractor.java
+++ b/cleartk-ml/src/main/java/org/cleartk/ml/feature/extractor/CleartkExtractor.java
@@ -360,7 +360,7 @@ public class CleartkExtractor<FOCUS_T extends Annotation, SEARCH_T extends Annot
         SEARCH_T ann = adjustedPos >= 0 ? anns.get(adjustedPos) : null;
         if (ann != null && bounds.contains(ann)) {
           for (Feature feature : extractor.extract(jCas, ann)) {
-            features.add(new ContextFeature(this.getName(), pos, feature));
+            features.add(new ContextFeature(this.getName(), pos, feature, featureName));
           }
         }
 


### PR DESCRIPTION
previously feature name from sub-extractors in ClearTkExtractor were silently discarded, for reasons I can't discern (presumably accidental?). Compare with the out-of-bounds features a few lines below, which preserve the name from the sub-extractor. Please advise if this was in fact a principled decision (and I'll abandon the PR). If not, I can provide other supporting changes you need for this very simple patch